### PR TITLE
Added support for overriding the RepresentationMode in Lua

### DIFF
--- a/projects/core/src/main/kotlin/site/siredvin/peripheralium/extra/plugins/AbstractItemStoragePlugin.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralium/extra/plugins/AbstractItemStoragePlugin.kt
@@ -23,7 +23,7 @@ abstract class AbstractItemStoragePlugin : IPeripheralPlugin {
     override val additionalType: String
         get() = PeripheralPluginUtils.Type.ITEM_STORAGE
 
-    open fun itemsImpl(mode: RepresentationMode): List<MutableMap<String, *>> {
+    open fun itemsImpl(mode: RepresentationMode = RepresentationMode.DETAILED): List<MutableMap<String, *>> {
         val result: MutableList<MutableMap<String, *>> = mutableListOf()
         storage.getItems().forEach {
             if (!it.isEmpty) {
@@ -35,7 +35,7 @@ abstract class AbstractItemStoragePlugin : IPeripheralPlugin {
 
     @LuaFunction(mainThread = true)
     fun items(): List<Map<String, *>> {
-        return itemsImpl(RepresentationMode.DETAILED)
+        return itemsImpl()
     }
 
     @LuaFunction(mainThread = true)

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralium/extra/plugins/AbstractItemStoragePlugin.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralium/extra/plugins/AbstractItemStoragePlugin.kt
@@ -10,6 +10,7 @@ import site.siredvin.peripheralium.api.peripheral.IPeripheralPlugin
 import site.siredvin.peripheralium.storages.item.ItemStorage
 import site.siredvin.peripheralium.storages.item.ItemStorageExtractor
 import site.siredvin.peripheralium.util.representation.LuaRepresentation
+import site.siredvin.peripheralium.util.representation.RepresentationMode
 import java.util.*
 import java.util.function.Predicate
 import kotlin.math.min
@@ -22,11 +23,11 @@ abstract class AbstractItemStoragePlugin : IPeripheralPlugin {
     override val additionalType: String
         get() = PeripheralPluginUtils.Type.ITEM_STORAGE
 
-    open fun itemsImpl(): List<MutableMap<String, *>> {
+    open fun itemsImpl(mode: RepresentationMode): List<MutableMap<String, *>> {
         val result: MutableList<MutableMap<String, *>> = mutableListOf()
         storage.getItems().forEach {
             if (!it.isEmpty) {
-                result.add(LuaRepresentation.forItemStack(it))
+                result.add(LuaRepresentation.forItemStack(it, mode))
             }
         }
         return result
@@ -34,7 +35,19 @@ abstract class AbstractItemStoragePlugin : IPeripheralPlugin {
 
     @LuaFunction(mainThread = true)
     fun items(): List<Map<String, *>> {
-        return itemsImpl()
+        return itemsImpl(RepresentationMode.DETAILED)
+    }
+
+    @LuaFunction(mainThread = true)
+    fun itemsModed(mode: String? = null): List<Map<String, *>> {
+        return itemsImpl(
+            when (mode) {
+                "base" -> RepresentationMode.BASE
+                "detailed" -> RepresentationMode.DETAILED
+                "full" -> RepresentationMode.FULL
+                else -> RepresentationMode.DETAILED
+            }
+        )
     }
 
     @LuaFunction(mainThread = true)


### PR DESCRIPTION
Wasn't previously possible, which caused some performance issues on my server as my lua scripts call that method pretty frequently and the default mode was `Detailed`, so it was pretty resource intensive.

Wasn't exactly sure if adding a new property to `itemsImpl` was a good choice as that changes the method signature, so perhaps it could be breaking to other plugins depening on this one?